### PR TITLE
[GRAPHQL] Finished Models and added relations

### DIFF
--- a/Back-end/app.js
+++ b/Back-end/app.js
@@ -6,11 +6,11 @@ const schema = require('./schema/schema');
 /// GETTING THE DB URL
 const mongoURL = process.env.MONGO;
 
-// mongoose.connect(mongoURL);
-// mongoose.connection.once('open', () => {
-//   // eslint-disable-next-line no-console
-//   console.log('Connected to databasee');
-// });
+mongoose.connect(mongoURL);
+mongoose.connection.once('open', () => {
+  // eslint-disable-next-line no-console
+  console.log('Connected to databasee');
+});
 
 const app = express();
 

--- a/Back-end/schema/schema.js
+++ b/Back-end/schema/schema.js
@@ -178,6 +178,19 @@ RentTC.addRelation(
         projection: { parkingId: 1 }, // required fields from Rent object, 1=true
     },
 );
+
+RentTC.addRelation(
+    'driver',
+    {
+        resolver: () => DriverTC.getResolver('findOne'),
+        prepareArgs: { // resolver `findOne` has `filter` arg, we may provide mongoose query to it
+            filter: (rent) => ({
+                _id: rent.driverId
+            })
+        },
+        projection: { driverId: 1 }, // required fields from Rent object, 1=true
+    },
+);
 // You may now use UserDTC to add fields to all Discriminators
 schemaComposer.Query.addFields({
     driverMany: DriverTC.getResolver('findMany'),

--- a/Back-end/schema/schema.js
+++ b/Back-end/schema/schema.js
@@ -25,7 +25,7 @@ const Dimensions = mongoose.Schema({
 }, { _id: false });
 
 const Car = mongoose.Schema({
-    dimensions : Dimensions,
+    dimensions: Dimensions,
     plates: String
 }, { _id: false });
 
@@ -42,7 +42,7 @@ const Parking = mongoose.Schema({
     images: [String],
     ubication: Ubication,
     price: Number,
-    dimensions : Dimensions,
+    dimensions: Dimensions,
     isUnderShade: Number, // to boolean and null if don't know
     isInside: Number,
     isWorking: Number,
@@ -53,8 +53,8 @@ const Parking = mongoose.Schema({
 const Rent = mongoose.Schema({
     parkingId: mongoose.Schema.Types.ObjectId,
     driverId: mongoose.Schema.Types.ObjectId,
-    startAt : mongoose.Schema.Types.Date,
-    endsAt : mongoose.Schema.Types.Date
+    startAt: mongoose.Schema.Types.Date,
+    endsAt: mongoose.Schema.Types.Date
 });
 
 
@@ -130,11 +130,13 @@ const OwnerTC = UserDTC.discriminator(OwnerModel);
 OwnerTC.addRelation(
     'parkings',
     {
-        resolver: () => ParkingTC.getResolver('findByIds'),
-        prepareArgs: { // resolver `findByIds` has `_ids` arg, let provide value to it
-            _ids: (source) => source.parkingsIds,
+        resolver: () => ParkingTC.getResolver('findMany'),
+        prepareArgs: { // resolver `findMany` has `filter` arg, we may provide mongoose query to it
+            filter: (owner) => ({
+                ownerId: owner._id,
+            })
         },
-        projection: { parkingsIds: 1 }, // point fields in source object, which should be fetched from DB
+        projection: { _id: 1 }, // required fields from Owner object, 1=true
     },
 );
 OwnerTC.addRelation(
@@ -142,15 +144,12 @@ OwnerTC.addRelation(
     {
         resolver: () => ParkingTC.getResolver('findMany'),
         prepareArgs: { // resolver `findMany` has `filter` arg, we may provide mongoose query to it
-            filter: (source) => ({
-                _operators: { // Applying criteria on fields which have
-                    // operators enabled for them (by default, indexed fields only)
-                    _id: { in: source.parkingsIds },
-                    isUnderShade: 1,
-                }
+            filter: (owner) => ({
+                ownerId: owner._id,
+                isUnderShade: 1
             })
         },
-        projection: { parkingsIds: 1 }, // required fields from source object, 1=true
+        projection: { _id: 1 }, // required fields from Owner object, 1=true
     },
 );
 // You may now use UserDTC to add fields to all Discriminators
@@ -158,8 +157,8 @@ schemaComposer.Query.addFields({
     driverMany: DriverTC.getResolver('findMany'),
     ownerMany: OwnerTC.getResolver('findMany'),
     userMany: UserDTC.getResolver('findMany'),
-    parkingMany : ParkingTC.getResolver('findMany'),
-    rentMany : RentTC.getResolver('findMany'),
+    parkingMany: ParkingTC.getResolver('findMany'),
+    rentMany: RentTC.getResolver('findMany'),
 
 });
 // Use DriverTC, `OwnerTC as any other ObjectTypeComposer.
@@ -167,14 +166,14 @@ schemaComposer.Mutation.addFields({
     driverCreate: DriverTC.getResolver('createOne'),
     ownerCreate: OwnerTC.getResolver('createOne'),
     userCreate: UserDTC.getResolver('createOne'),
-    parkingCreate : ParkingTC.getResolver('createOne'),
-    rentCreate : RentTC.getResolver('createOne'),
+    parkingCreate: ParkingTC.getResolver('createOne'),
+    rentCreate: RentTC.getResolver('createOne'),
 
     driverUpdate: DriverTC.getResolver('updateOne'),
     ownerUpdate: OwnerTC.getResolver('updateOne'),
     userUpdate: UserDTC.getResolver('updateOne'),
-    parkingUpdate : ParkingTC.getResolver('updateOne'),
-    rentUpdate : RentTC.getResolver('updateOne'),
+    parkingUpdate: ParkingTC.getResolver('updateOne'),
+    rentUpdate: RentTC.getResolver('updateOne'),
 
 });
 

--- a/Back-end/schema/schema.js
+++ b/Back-end/schema/schema.js
@@ -165,6 +165,19 @@ ParkingTC.addRelation(
         projection: { ownerId: 1 }, // required fields from Parking object, 1=true
     },
 );
+
+RentTC.addRelation(
+    'parking',
+    {
+        resolver: () => ParkingTC.getResolver('findOne'),
+        prepareArgs: { // resolver `findOne` has `filter` arg, we may provide mongoose query to it
+            filter: (rent) => ({
+                _id: rent.parkingId
+            })
+        },
+        projection: { parkingId: 1 }, // required fields from Rent object, 1=true
+    },
+);
 // You may now use UserDTC to add fields to all Discriminators
 schemaComposer.Query.addFields({
     driverMany: DriverTC.getResolver('findMany'),

--- a/Back-end/schema/schema.js
+++ b/Back-end/schema/schema.js
@@ -126,7 +126,7 @@ const DriverTC = UserDTC.discriminator(DriverModel, driverTypeConverterOptions);
 const OwnerTC = UserDTC.discriminator(OwnerModel);
 // baseOptions -> customizationsOptions applied
 
-// console.log('Resolvers',DriverTC.getResolvers())
+// Owner relations
 OwnerTC.addRelation(
     'parkings',
     {
@@ -153,6 +153,22 @@ OwnerTC.addRelation(
     },
 );
 
+/// Driver Relations
+DriverTC.addRelation(
+    'rents',
+    {
+        resolver: () => RentTC.getResolver('findMany'),
+        prepareArgs: { // resolver `findMany` has `filter` arg, we may provide mongoose query to it
+            filter: (driver) => ({
+                driverId: driver._id
+            })
+        },
+        projection: { _id: 1 }, // required fields from Driver object, 1=true
+    },
+);
+
+
+//Parking Relations
 ParkingTC.addRelation(
     'owner',
     {
@@ -166,6 +182,20 @@ ParkingTC.addRelation(
     },
 );
 
+ParkingTC.addRelation(
+    'rents',
+    {
+        resolver: () => RentTC.getResolver('findMany'),
+        prepareArgs: { // resolver `findMany` has `filter` arg, we may provide mongoose query to it
+            filter: (parking) => ({
+                parkingId: parking._id
+            })
+        },
+        projection: { _id: 1 }, // required fields from Parking object, 1=true
+    },
+);
+
+//Rent relations
 RentTC.addRelation(
     'parking',
     {
@@ -191,6 +221,7 @@ RentTC.addRelation(
         projection: { driverId: 1 }, // required fields from Rent object, 1=true
     },
 );
+
 // You may now use UserDTC to add fields to all Discriminators
 schemaComposer.Query.addFields({
     driverMany: DriverTC.getResolver('findMany'),

--- a/Back-end/schema/schema.js
+++ b/Back-end/schema/schema.js
@@ -170,11 +170,11 @@ schemaComposer.Mutation.addFields({
     parkingCreate : ParkingTC.getResolver('createOne'),
     rentCreate : RentTC.getResolver('createOne'),
 
-    driverCreate: DriverTC.getResolver('createOne'),
-    ownerCreate: OwnerTC.getResolver('createOne'),
-    userCreate: UserDTC.getResolver('createOne'),
-    parkingCreate : ParkingTC.getResolver('createOne'),
-    rentCreate : RentTC.getResolver('createOne'),
+    driverUpdate: DriverTC.getResolver('updateOne'),
+    ownerUpdate: OwnerTC.getResolver('updateOne'),
+    userUpdate: UserDTC.getResolver('updateOne'),
+    parkingUpdate : ParkingTC.getResolver('updateOne'),
+    rentUpdate : RentTC.getResolver('updateOne'),
 
 });
 

--- a/Back-end/schema/schema.js
+++ b/Back-end/schema/schema.js
@@ -25,7 +25,7 @@ const Dimensions = mongoose.Schema({
 }, { _id: false });
 
 const Car = mongoose.Schema({
-    dimensions : Dimensions
+    dimensions : Dimensions,
     plates: String
 }, { _id: false });
 
@@ -45,7 +45,7 @@ const Parking = mongoose.Schema({
     dimensions : Dimensions,
     isUnderShade: Number, // to boolean and null if don't know
     isInside: Number,
-    isWorking: Number
+    isWorking: Number,
     totalLots: Number,
     availableLots: Number
 });
@@ -156,15 +156,26 @@ OwnerTC.addRelation(
 // You may now use UserDTC to add fields to all Discriminators
 schemaComposer.Query.addFields({
     driverMany: DriverTC.getResolver('findMany'),
-    personMany: OwnerTC.getResolver('findMany'),
+    ownerMany: OwnerTC.getResolver('findMany'),
     userMany: UserDTC.getResolver('findMany'),
+    parkingMany : ParkingTC.getResolver('findMany'),
+    rentMany : RentTC.getResolver('findMany'),
 
 });
 // Use DriverTC, `OwnerTC as any other ObjectTypeComposer.
 schemaComposer.Mutation.addFields({
     driverCreate: DriverTC.getResolver('createOne'),
-    personCreate: OwnerTC.getResolver('createOne'),
+    ownerCreate: OwnerTC.getResolver('createOne'),
     userCreate: UserDTC.getResolver('createOne'),
+    parkingCreate : ParkingTC.getResolver('createOne'),
+    rentCreate : RentTC.getResolver('createOne'),
+
+    driverCreate: DriverTC.getResolver('createOne'),
+    ownerCreate: OwnerTC.getResolver('createOne'),
+    userCreate: UserDTC.getResolver('createOne'),
+    parkingCreate : ParkingTC.getResolver('createOne'),
+    rentCreate : RentTC.getResolver('createOne'),
+
 });
 
 const schema = schemaComposer.buildSchema();
@@ -182,7 +193,7 @@ const schema = schemaComposer.buildSchema();
                             modelNumber
                             }
                         }
-                        personCreate(record: {name: "mernxl", dob: 57275272}) {
+                        ownerCreate(record: {name: "mernxl", dob: 57275272}) {
                             record {
                             __typename
                             type
@@ -198,7 +209,7 @@ const schema = schemaComposer.buildSchema();
                     record: { __typename: 'Driver', type: 'Driver',
                      name: 'Queue XL', modelNumber: 360 },
                 },
-                personCreate: {
+                ownerCreate: {
                     record: { __typename: 'Owner', type: 'Owner', name: 'mernxl', dob: 57275272 },
                 },
             },

--- a/Back-end/schema/schema.js
+++ b/Back-end/schema/schema.js
@@ -152,6 +152,19 @@ OwnerTC.addRelation(
         projection: { _id: 1 }, // required fields from Owner object, 1=true
     },
 );
+
+ParkingTC.addRelation(
+    'owner',
+    {
+        resolver: () => OwnerTC.getResolver('findOne'),
+        prepareArgs: { // resolver `findOne` has `filter` arg, we may provide mongoose query to it
+            filter: (parking) => ({
+                _id: parking.ownerId
+            })
+        },
+        projection: { ownerId: 1 }, // required fields from Parking object, 1=true
+    },
+);
 // You may now use UserDTC to add fields to all Discriminators
 schemaComposer.Query.addFields({
     driverMany: DriverTC.getResolver('findMany'),

--- a/Back-end/schema/schema.js
+++ b/Back-end/schema/schema.js
@@ -48,14 +48,14 @@ const Parking = mongoose.Schema({
     isWorking: Number,
     totalLots: Number,
     availableLots: Number
-});
+},{ timestamps: true });
 
 const Rent = mongoose.Schema({
     parkingId: mongoose.Schema.Types.ObjectId,
     driverId: mongoose.Schema.Types.ObjectId,
     startAt: mongoose.Schema.Types.Date,
     endsAt: mongoose.Schema.Types.Date
-});
+},{ timestamps: true });
 
 
 // DEFINE USER SCHEMAS
@@ -75,7 +75,7 @@ const User = new mongoose.Schema({
     phone: String,
     address: String,
     cards: [BankCard]
-});
+},{ timestamps: true });
 
 // DEFINE DISCRIMINATOR SCHEMAS
 const Driver = new mongoose.Schema({


### PR DESCRIPTION
## DESCRIPTION
- Finished Models for Users, Parkings, Rents and aux as Car, Dimensions and BankCards
- Added Relations: Owner has Parkings, Owner has Parkings with shade, Driver has Rents, Parking belongs to Owner, Parking has Rents, Rent belongs to Parkings, Rent belongs to Driver.


## MILESTONES
- MVP - BACK-END - GRAPHQL - Models and Relations

## TEST PLAN

At the Left we can see the fields we can query

Following the flow Owner has Parkings that have Rents that belongs to Drivers

Owner:
<img width="1178" alt="Screen Shot 2022-07-25 at 4 53 07 PM" src="https://user-images.githubusercontent.com/37078683/180894554-91d8a27b-4c46-4660-8de6-d786f02f2441.png">

Parking
<img width="1458" alt="Screen Shot 2022-07-25 at 4 54 25 PM" src="https://user-images.githubusercontent.com/37078683/180894605-98fcb222-8d6f-4590-8678-264ef5ce2a94.png">

Rent
<img width="1658" alt="Screen Shot 2022-07-25 at 4 55 16 PM" src="https://user-images.githubusercontent.com/37078683/180894635-75a4f2bc-7df8-4f2e-807a-c2d4855d0fee.png">

Driver
<img width="1558" alt="Screen Shot 2022-07-25 at 4 55 53 PM" src="https://user-images.githubusercontent.com/37078683/180894670-20912926-015a-425a-932e-608750444c70.png">


## NEXT STEPS
I was trying to get the current rents (with current date between startAt and endsAt) using graphql operators but could figure out yet how to enable them (as not all of them are enabled by default for performance reasons); I think I will filter rents in Node



