### PR TITLE
[REGISTER] added mutation definition and made query from REGISTER screen

### DIFF
--- a/Front-end/parquick/src/components/Register/Register.jsx
+++ b/Front-end/parquick/src/components/Register/Register.jsx
@@ -32,6 +32,7 @@ function Register(): React.MixedElement {
 
     function handleOnSubmitRegister(event) {
         event.preventDefault();
+        // Added in the previous commit
         client
             .mutate({
                 mutation: USER_REGISTER(user),

--- a/Front-end/parquick/src/queries/userQueries.js
+++ b/Front-end/parquick/src/queries/userQueries.js
@@ -27,6 +27,7 @@ export const USER_LOGIN = (email : string, password : string) => {
     `;
 }
 
+// mutation for register a new user
 export const USER_REGISTER = (user : User) => {
     return gql`
     mutation userRegister{


### PR DESCRIPTION
## DESCRIPTION
- Added register mutation string to be re-used with parameters
- Made a file queries/client.js to import with less code the ApolloClient
- Added that client to REGISTER to make queries with the data from the form

## MILESTONES
- MVP - REGISTER

## TEST PLAN
Payload:
<img width="1728" alt="Screen Shot 2022-07-28 at 4 46 25 PM" src="https://user-images.githubusercontent.com/37078683/181656244-30705ccc-76b3-4a5c-9442-fb26487768f4.png">

Result:
<img width="1728" alt="Screen Shot 2022-07-28 at 4 46 38 PM" src="https://user-images.githubusercontent.com/37078683/181656261-d556b2be-2141-473f-b51e-ff407105c069.png">
