### PR TITLE
[CHAT screen] Fetching and displaying conversations for a user 

### DIFF
--- a/Front-end/parquick/src/components/Messenger/Messenger.jsx
+++ b/Front-end/parquick/src/components/Messenger/Messenger.jsx
@@ -21,6 +21,7 @@ function Messenger(): React.MixedElement {
         // Todo : store the message
     };
 
+    // Fetching conversations for the user
     useEffect(() => {
         if (user?.type && user?._id) {
             client

--- a/Front-end/parquick/src/queries/conversation.js
+++ b/Front-end/parquick/src/queries/conversation.js
@@ -4,6 +4,7 @@ import { gql } from '@apollo/client';
 
 const otherUserType = { "driver": "owner", "owner": "driver" }
 
+// Getting queries for a certain user
 export const GET_MY_CONVERSATIONS = (userType: string, userId: string) => {
     return gql`
 query MyConversations{

--- a/Front-end/parquick/src/types/Conversation.js
+++ b/Front-end/parquick/src/types/Conversation.js
@@ -1,5 +1,6 @@
 // @flow
 
+// created conversation type
 export type Conversation = {
     _id : string,
     user: {


### PR DESCRIPTION
## DESCRIPTION
- Added query to get conversations for a user given their id, getting the other participant with Graphql alias
- Displaying of those conversations

## MILESTONES
CHAT - screens - conversations

## TEST PLAN
Query
<img width="1281" alt="Screen Shot 2022-08-01 at 6 12 22 PM" src="https://user-images.githubusercontent.com/37078683/182441705-5881c5c6-4d2a-4c01-b488-928b7da04465.png">

Result:
<img width="1728" alt="Screen Shot 2022-08-01 at 6 15 25 PM" src="https://user-images.githubusercontent.com/37078683/182441761-ff4c7cf0-1b04-480e-8c84-f9b677025c7d.png">


## NOTES
The complete code related to this is in the last commit of the previous PR, but was accidentally added there