### PR TITLE
[CHAT screen] retrieving and displaying messages after selecting conversation

### DIFF
--- a/Front-end/parquick/src/components/Messenger/Message/Message.css
+++ b/Front-end/parquick/src/components/Messenger/Message/Message.css
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     margin-top: 20px;
+    align-items: flex-start;
   }
 
   .message-container{

--- a/Front-end/parquick/src/components/Messenger/Messenger.css
+++ b/Front-end/parquick/src/components/Messenger/Messenger.css
@@ -50,3 +50,16 @@
   .chat-submit-button:hover {
     background-color: rgb(95, 168, 231);
   }
+
+  .no-chat-selected {
+    margin: 20px auto;
+    font-size: 50px;
+    color: rgba(160, 159, 250, 0.582);
+    cursor: default;
+  }
+  .no-chatted-before {
+    margin: 20px auto;
+    font-size: 50px;
+    color: rgba(160, 159, 250, 0.582);
+    cursor: default;
+  }

--- a/Front-end/parquick/src/components/Messenger/Messenger.jsx
+++ b/Front-end/parquick/src/components/Messenger/Messenger.jsx
@@ -5,16 +5,18 @@ import { useUser } from '../../contexts/UserContext';
 import Conversation from './Conversation/Conversation';
 import Message from './Message/Message';
 import './Messenger.css';
-import { testMessages } from "../../types/Message";
 import { client } from '../../queries/client';
 import { GET_MY_CONVERSATIONS } from '../../queries/conversation';
 import type { User } from "../../types/User";
+import { GET_MESSAGES_FROM_THIS_CONVERSATION } from '../../queries/message';
 
 function Messenger(): React.MixedElement {
 
     const { user } = useUser < User > ();
     const [newMessage, setNewMessage] = useState("");
     const [conversations, setConversations] = useState([])
+    const [currentChat, setCurrentChat] = useState({});
+    const [messages, setMessages] = useState([]);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -29,12 +31,24 @@ function Messenger(): React.MixedElement {
                     query: GET_MY_CONVERSATIONS(user.type.toLowerCase(), user._id),
                 })
                 .then((result) => {
-
-                    // TODO: update the conversations
                     setConversations(result.data.conversationMany)
                 });
         }
     }, [])
+
+    // Getting the messages fro the current chat
+    useEffect(() => {
+        if (currentChat._id) {
+            client
+                .query({
+                    query: GET_MESSAGES_FROM_THIS_CONVERSATION(currentChat._id),
+                })
+                .then((result) => {
+                    setMessages(result.data.messageMany)
+                });
+        }
+
+    }, [currentChat]);
 
 
     return (
@@ -45,30 +59,50 @@ function Messenger(): React.MixedElement {
                     <div className="chat-menu-container">
                         <h3 className='conversations-title'>Conversations</h3>
                         {conversations.map((conv) => {
-                            return <Conversation conversation={conv} key={conv._id} />
+                            return <div onClick={() => setCurrentChat(conv)} key={conv._id}>
+                                <Conversation conversation={conv} />
+                            </div>
+
                         })}
                     </div>
                 </div>
                 <div className="chat-box">
                     <div className="chat-box-container">
-                        <div className="chatbox-messages">
-                            {
-                                testMessages.map((mes) => {
-                                    return <Message message={mes} own={user._id === mes.senderId} key={mes._id} />
-                                })
-                            }
-                        </div>
-                        <div className="chatbox-input">
-                            <textarea
-                                className="chat-message-input"
-                                placeholder="write something..."
-                                onChange={(e) => setNewMessage(e.target.value)}
-                                value={newMessage}
-                            ></textarea>
-                            <button className="chat-submit-button" onClick={handleSubmit}>
-                                Send
-                            </button>
-                        </div>
+                        {currentChat?._id ?
+                            <>
+                                {messages?.length !== 0 ?
+                                    <div className="chatbox-messages">
+                                        {
+                                            messages.map((mes) => {
+                                                return <Message message={mes} own={user._id === mes.senderId} key={mes._id} />
+                                            })
+                                        }
+                                    </div>
+                                    :
+                                    <>
+                                        <span className="no-chatted-before">
+                                            {`V`} Send the first message. {`V`}
+                                        </span>
+                                    </>}
+                                <div className="chatbox-input">
+                                    <textarea
+                                        className="chat-message-input"
+                                        placeholder="write something..."
+                                        onChange={(e) => setNewMessage(e.target.value)}
+                                        value={newMessage}
+                                    ></textarea>
+                                    <button className="chat-submit-button" onClick={handleSubmit}>
+                                        Send
+                                    </button>
+                                </div>
+                            </>
+                            :
+                            <>
+                                <span className="no-chat-selected">
+                                    {`<==`} Open a conversation to start a chat.
+                                </span>
+                            </>
+                        }
                     </div>
                 </div>
             </div>

--- a/Front-end/parquick/src/queries/message.js
+++ b/Front-end/parquick/src/queries/message.js
@@ -1,0 +1,26 @@
+//
+
+import { gql } from '@apollo/client';
+
+
+// Getting queries for a certain user
+export const GET_MESSAGES_FROM_THIS_CONVERSATION = (conversationId: string) => {
+    return gql`
+    query MessageMany{
+        messageMany(filter:  {
+          conversationId: "${conversationId}"
+        }) {
+          _id
+          conversationId
+          text
+          createdAt
+          senderId
+          sender {
+            firstName
+            lastName
+            type
+            _id
+          }
+        }
+      }
+`};


### PR DESCRIPTION
## DESCRIPTION
- Added query for getting messages given the conversation Id
- Displaying of messages for the selected conversation
- Helper text to advice click a conversation when no selected, and write a message in empty conversations

## MILESTONES
CHAT - screnn - displaying of conversations' messages

## TEST PLAN
Query :
<img width="1283" alt="Screen Shot 2022-08-02 at 12 03 25 PM" src="https://user-images.githubusercontent.com/37078683/182453706-f429703f-bc4f-4710-b665-d715798605a3.png">

Beginning
<img width="1728" alt="Screen Shot 2022-08-02 at 12 05 17 PM" src="https://user-images.githubusercontent.com/37078683/182453779-fc10490f-82b9-4335-8226-a1301880ca93.png">

After clicking conversation 1:
<img width="1728" alt="Screen Shot 2022-08-02 at 12 04 26 PM" src="https://user-images.githubusercontent.com/37078683/182453905-4c403f99-9d13-488f-bba1-1c28597d5952.png">

Empty conversation
<img width="1728" alt="Screen Shot 2022-08-02 at 12 05 49 PM" src="https://user-images.githubusercontent.com/37078683/182453993-7c76d0d4-1ff5-423c-8e91-7f1e28b87465.png">

Other conversation
<img width="1727" alt="Screen Shot 2022-08-02 at 12 05 37 PM" src="https://user-images.githubusercontent.com/37078683/182465208-a1d7d46b-d375-41e5-bc00-82130383c648.png">
