### PR TITLE
[CHAT screen] marked selected conversation and put isLoading Messages

### DIFF
--- a/Front-end/parquick/src/components/Messenger/Conversation/Conversation.css
+++ b/Front-end/parquick/src/components/Messenger/Conversation/Conversation.css
@@ -5,6 +5,9 @@
     cursor: pointer;
     margin-top: 20px;
   }
+  .conversation.selected {
+    background-color: rgba(245, 243, 243, 0.616);
+  }
 
   .conversation:hover {
     background-color: rgb(245, 243, 243);

--- a/Front-end/parquick/src/components/Messenger/Conversation/Conversation.jsx
+++ b/Front-end/parquick/src/components/Messenger/Conversation/Conversation.jsx
@@ -4,13 +4,13 @@ import type { Conversation as ConvType } from '../../../types/Conversation';
 import './Conversation.css';
 
 type PropsConversation = {
-    conversation : ConvType
-
+    conversation : ConvType,
+    isSelected: boolean
 }
 
-function Conversation({conversation} : PropsConversation): React.MixedElement {
+function Conversation({conversation, isSelected} : PropsConversation): React.MixedElement {
     return <>
-        <div className="conversation">
+        <div className={isSelected ? "conversation selected" : "conversation"}>
             <img
                 className="conversation-img"
                 src="https://picsum.photos/id/222/408/485"

--- a/Front-end/parquick/src/components/Messenger/Messenger.css
+++ b/Front-end/parquick/src/components/Messenger/Messenger.css
@@ -51,15 +51,9 @@
     background-color: rgb(95, 168, 231);
   }
 
-  .no-chat-selected {
+  .no-chat-selected, .no-chatted-before, .loading-messages {
     margin: 20px auto;
     font-size: 50px;
-    color: rgba(160, 159, 250, 0.582);
-    cursor: default;
-  }
-  .no-chatted-before {
-    margin: 20px auto;
-    font-size: 50px;
-    color: rgba(160, 159, 250, 0.582);
+    color: rgba(71, 71, 109, 0.582);
     cursor: default;
   }

--- a/Front-end/parquick/src/components/Messenger/Messenger.jsx
+++ b/Front-end/parquick/src/components/Messenger/Messenger.jsx
@@ -59,8 +59,11 @@ function Messenger(): React.MixedElement {
                     <div className="chat-menu-container">
                         <h3 className='conversations-title'>Conversations</h3>
                         {conversations.map((conv) => {
-                            return <div onClick={() => setCurrentChat(conv)} key={conv._id}>
-                                <Conversation conversation={conv} />
+                            return <div onClick={() => setCurrentChat(conv)} key={conv._id} >
+                                <Conversation
+                                    conversation={conv}
+                                    isSelected={currentChat?._id && currentChat?._id === conv._id}
+                                />
                             </div>
 
                         })}

--- a/Front-end/parquick/src/components/Messenger/Messenger.jsx
+++ b/Front-end/parquick/src/components/Messenger/Messenger.jsx
@@ -17,6 +17,7 @@ function Messenger(): React.MixedElement {
     const [conversations, setConversations] = useState([])
     const [currentChat, setCurrentChat] = useState({});
     const [messages, setMessages] = useState([]);
+    const [isLoadingMessages, setIsLoadingMessages] = useState(false);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -39,12 +40,14 @@ function Messenger(): React.MixedElement {
     // Getting the messages fro the current chat
     useEffect(() => {
         if (currentChat._id) {
+            setIsLoadingMessages(true)
             client
                 .query({
                     query: GET_MESSAGES_FROM_THIS_CONVERSATION(currentChat._id),
                 })
                 .then((result) => {
                     setMessages(result.data.messageMany)
+                    setIsLoadingMessages(false);
                 });
         }
 
@@ -73,20 +76,27 @@ function Messenger(): React.MixedElement {
                     <div className="chat-box-container">
                         {currentChat?._id ?
                             <>
-                                {messages?.length !== 0 ?
-                                    <div className="chatbox-messages">
-                                        {
-                                            messages.map((mes) => {
-                                                return <Message message={mes} own={user._id === mes.senderId} key={mes._id} />
-                                            })
-                                        }
-                                    </div>
-                                    :
-                                    <>
-                                        <span className="no-chatted-before">
-                                            {`V`} Send the first message. {`V`}
+                                {
+                                    isLoadingMessages ?
+                                        <span className="loading-messages">
+                                             Loading messages ...
                                         </span>
-                                    </>}
+                                        :
+
+                                        messages?.length !== 0 ?
+                                            <div className="chatbox-messages">
+                                                {
+                                                    messages.map((mes) => {
+                                                        return <Message message={mes} own={user._id === mes.senderId} key={mes._id} />
+                                                    })
+                                                }
+                                            </div>
+                                            :
+                                            <>
+                                                <span className="no-chatted-before">
+                                                    {`V`} Send the first message. {`V`}
+                                                </span>
+                                            </>}
                                 <div className="chatbox-input">
                                     <textarea
                                         className="chat-message-input"


### PR DESCRIPTION
## DESCRIPTION
- Added different color to the selected conversation when clicked
- Added "Loading messages..." text . 

## MILESTONES
CHAT- screen - current conversation
CHAT- screen - loading messages

## TEST PLAN
Beginning
<img width="1059" alt="Screen Shot 2022-08-02 at 1 52 48 PM" src="https://user-images.githubusercontent.com/37078683/182471803-530ec3af-52a9-4169-ae42-00969def97e2.png">


After selecting a conversation
<img width="1058" alt="Screen Shot 2022-08-02 at 1 53 12 PM" src="https://user-images.githubusercontent.com/37078683/182471842-3709749c-facd-4fde-ac7a-1d1be21c8b45.png">

For "Loading Messages" : The fetching is so fast I couldn't take a screenshot, and recording a GIF will take unnecessary effort
