### PR TITLE
[CHAT screen] Sending, storing and displaying sent messages

### DIFF
--- a/Front-end/parquick/src/components/Messenger/Message/Message.css
+++ b/Front-end/parquick/src/components/Messenger/Message/Message.css
@@ -7,6 +7,7 @@
 
   .message-container{
       display: flex;
+      overflow-wrap: break-word;
   }
 
   .message-img {

--- a/Front-end/parquick/src/components/Messenger/Messenger.css
+++ b/Front-end/parquick/src/components/Messenger/Messenger.css
@@ -46,9 +46,17 @@
     background-color: rgb(69, 120, 165);
     color: white;
   }
+  .chat-submit-button.no-message {
+    background-color: rgb(146, 155, 161);
+    color: white;
+    cursor: default;
+  }
 
   .chat-submit-button:hover {
     background-color: rgb(95, 168, 231);
+  }
+  .chat-submit-button.no-message:hover {
+    background-color: rgb(146, 155, 161);
   }
 
   .no-chat-selected, .no-chatted-before, .loading-messages {

--- a/Front-end/parquick/src/components/Messenger/Messenger.jsx
+++ b/Front-end/parquick/src/components/Messenger/Messenger.jsx
@@ -8,7 +8,7 @@ import './Messenger.css';
 import { client } from '../../queries/client';
 import { GET_MY_CONVERSATIONS } from '../../queries/conversation';
 import type { User } from "../../types/User";
-import { GET_MESSAGES_FROM_THIS_CONVERSATION } from '../../queries/message';
+import { CREATE_MESSAGE_FROM_USER_TO_CONVERSATION, GET_MESSAGES_FROM_THIS_CONVERSATION } from '../../queries/message';
 
 function Messenger(): React.MixedElement {
 
@@ -18,11 +18,6 @@ function Messenger(): React.MixedElement {
     const [currentChat, setCurrentChat] = useState({});
     const [messages, setMessages] = useState([]);
     const [isLoadingMessages, setIsLoadingMessages] = useState(false);
-
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        // Todo : store the message
-    };
 
     // Fetching conversations for the user
     useEffect(() => {
@@ -53,6 +48,25 @@ function Messenger(): React.MixedElement {
 
     }, [currentChat]);
 
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        if (currentChat?._id && user?._id && messages !== "") {
+            client
+                .mutate({
+                    mutation:
+                        CREATE_MESSAGE_FROM_USER_TO_CONVERSATION(currentChat._id, newMessage, user._id),
+                })
+                .then((result) => {
+
+                    setMessages((prev) => {
+                        return [...prev, result.data.messageCreate.record]
+                    })
+                    setNewMessage("")
+                });
+        }
+        // Todo : store the message
+    };
 
     return (
         <>
@@ -79,7 +93,7 @@ function Messenger(): React.MixedElement {
                                 {
                                     isLoadingMessages ?
                                         <span className="loading-messages">
-                                             Loading messages ...
+                                            Loading messages ...
                                         </span>
                                         :
 
@@ -104,7 +118,10 @@ function Messenger(): React.MixedElement {
                                         onChange={(e) => setNewMessage(e.target.value)}
                                         value={newMessage}
                                     ></textarea>
-                                    <button className="chat-submit-button" onClick={handleSubmit}>
+                                    <button
+                                        className={newMessage !== "" ? "chat-submit-button" : "chat-submit-button no-message"}
+                                        onClick={handleSubmit}
+                                        disabled={newMessage == "" ? true : false}>
                                         Send
                                     </button>
                                 </div>

--- a/Front-end/parquick/src/queries/message.js
+++ b/Front-end/parquick/src/queries/message.js
@@ -36,13 +36,16 @@ export const CREATE_MESSAGE_FROM_USER_TO_CONVERSATION =
           senderId: "${senderId}"
         }) {
           record {
+            _id
             conversationId
             text
+            createdAt
+            senderId
             sender {
-              _id
-              firstName
-              lastName
-              type
+                firstName
+                lastName
+                type
+                _id
             }
           }
         }


### PR DESCRIPTION
## DESCRIPTION
- Enabled sending message to Graphql to be stored at MongoDB

## MILESTONES
CHAT - CLIENT - Sending messages

## TEST PLAN
Sent message
<img width="1728" alt="Screen Shot 2022-08-02 at 3 14 28 PM" src="https://user-images.githubusercontent.com/37078683/182482982-918d739a-fe08-40b2-b687-49c3f242ea07.png">


## TO BE FIXED
- use variables in the mutation, as graphql parameters doesn't support multiline values (AFAIK)

## TO DO
- Set a fixed width for the chat, hide previous messages if there too many, scroll to the newest message
