### PR TITLE
[MAIN-DRIVER] separated onHover and onClick windows. Deleted unnecesary async/await

### DIFF
--- a/Front-end/parquick/src/components/Map/Map.css
+++ b/Front-end/parquick/src/components/Map/Map.css
@@ -17,3 +17,7 @@
 .parking-marker-img:hover {
     opacity: 0.7;
   }
+
+  .click-advice{
+      font-size: smaller;
+  }


### PR DESCRIPTION
## DESCRIPTION
- Deleted unnecessary async/await. I was sure there were there because it was needed at that time, but the project works without them, so bye bye
- Made a different window for onHover 
- Kept a window for onClick if the user is more interested in one parking

## MILESTONES
MVP - MAIN-DRIVER - MAP - Info windows


## TEST PLAN

Both windows living together
<img width="846" alt="Screen Shot 2022-08-04 at 6 20 16 PM" src="https://user-images.githubusercontent.com/37078683/182981866-b2e77b9f-e124-4bc9-9bda-73d1ede21c41.png">
OnClick at the left with more info, and onHover to the right for quick view