### PR TITLE
[PARKING screen] creating a rent record after clicking 'rent'

### DIFF
--- a/Front-end/parquick/src/components/Parking/Parking.jsx
+++ b/Front-end/parquick/src/components/Parking/Parking.jsx
@@ -25,7 +25,7 @@ function Parking(): React.MixedElement {
             setParking(data.parkingById);
         }
     }, [data])
-
+    // Calling mutation
     const makeRent = async (todayDate, endDate) => {
         client
             .mutate({
@@ -35,7 +35,7 @@ function Parking(): React.MixedElement {
                 // Todo: create a conversation
             });
     }
-
+    // Getting date format
     function handleOnClickRent(event) {
         const todayDate = new Date().toLocaleDateString()
         const endDate = new Date(selectedDate).toLocaleDateString();

--- a/Front-end/parquick/src/queries/rent.js
+++ b/Front-end/parquick/src/queries/rent.js
@@ -1,6 +1,7 @@
 //
 import { gql } from '@apollo/client';
 
+// Mutation for record a rent
 export const CREATE_RENT = (parkingId: string, driverId: string, startAt: string, endsAt: string) => {
     return gql`
     mutation createRent {


### PR DESCRIPTION
## DESCRIPTION
The content of this PR is below of the commented code, but was put in the last commit of the previous PR by mistake
- Added mutation template in the client to create a rent
- Enabled rent button to call the mutation

## MILESTONES
MVP - PARKING - rent a parking

## TEST PLAN
After clicking the rent button without telling the end date, we rent a parking for that same day:
<img width="1728" alt="Screen Shot 2022-08-05 at 3 51 48 PM" src="https://user-images.githubusercontent.com/37078683/183221123-7c2a4378-4f1d-4fc5-a1c5-54cf16274e10.png">

## TO DO
- fix date format warning
- validate not selecting previous dates
