### PR TITLE
[CLIENT-CONVERSATION] Creating a conversation after rent is created

### DIFF
--- a/Front-end/parquick/src/components/Parking/Parking.jsx
+++ b/Front-end/parquick/src/components/Parking/Parking.jsx
@@ -8,6 +8,7 @@ import { GET_PARKING_BY_ID } from '../../queries/parkingQueries';
 import { client } from '../../queries/client';
 import { CREATE_RENT } from '../../queries/rent';
 import { useUser } from '../../contexts/UserContext';
+import { CREATE_CONVERSATION } from '../../queries/conversation';
 
 function Parking(): React.MixedElement {
     const { parkingId } = useParams();
@@ -25,17 +26,29 @@ function Parking(): React.MixedElement {
             setParking(data.parkingById);
         }
     }, [data])
-    // Calling mutation
-    const makeRent = async (todayDate, endDate) => {
+
+    const makeConversation = (driverId, ownerId) => {
+        client
+            .mutate({
+                mutation: CREATE_CONVERSATION(driverId, ownerId),
+            })
+            .then((result) => {
+                // Todo: Tell user the conversation was created
+            });
+    }
+
+    const makeRent = (todayDate, endDate) => {
         client
             .mutate({
                 mutation: CREATE_RENT(parkingId, user._id, todayDate, endDate),
             })
             .then((result) => {
-                // Todo: create a conversation
+                const driverId = result.data.rentCreate.record.driverId;
+                const ownerId = result.data.rentCreate.record.parking.owner._id;
+                makeConversation(driverId, ownerId)
             });
     }
-    // Getting date format
+
     function handleOnClickRent(event) {
         const todayDate = new Date().toLocaleDateString()
         const endDate = new Date(selectedDate).toLocaleDateString();

--- a/Front-end/parquick/src/queries/conversation.js
+++ b/Front-end/parquick/src/queries/conversation.js
@@ -1,5 +1,4 @@
 //
-
 import { gql } from '@apollo/client';
 
 const otherUserType = { "driver": "owner", "owner": "driver" }
@@ -17,6 +16,30 @@ query MyConversations{
         lastName
       }
       _id
+    }
+  }
+`};
+
+export const CREATE_CONVERSATION = (driverId: string, ownerId: string) => {
+  return gql`
+  mutation ConversationCreate{
+    conversationCreate(record: {
+      ownerId: "${ownerId}",
+      driverId: "${driverId}"
+    }) {
+      record {
+        driver {
+          _id
+          firstName
+          lastName
+        }
+        owner {
+          _id
+          firstName
+          lastName
+        }
+        _id
+      }
     }
   }
 `};

--- a/Front-end/parquick/src/queries/rent.js
+++ b/Front-end/parquick/src/queries/rent.js
@@ -17,6 +17,11 @@ export const CREATE_RENT = (parkingId: string, driverId: string, startAt: string
             startAt
             endsAt
             _id
+            parking {
+                owner {
+                  _id
+                }
+              }
           }
         }
       }


### PR DESCRIPTION
## DESCRIPTION
- Modified the data returned by the creation of a rent to get the id of the owner of the parking
- Added template to create a conversation
- Calling the mutation to create conversations after the rent is confirmed

## MILESTONES
CHAT - Create conversations after confirming rent

## TEST PLAN
Result of the query for creating a rent, and the result of creating a conversation after:
<img width="1728" alt="Screen Shot 2022-08-05 at 4 10 38 PM" src="https://user-images.githubusercontent.com/37078683/183222832-53159647-436c-413d-8e7e-3b95bd041ecb.png">
The console.log was for testing, it is not in the code now.

Messenger screen showing the same user(driver, right) with the created conversations (with owner 2, left) at testing:
<img width="1718" alt="Screen Shot 2022-08-05 at 4 23 00 PM" src="https://user-images.githubusercontent.com/37078683/183222994-ad19cf5b-2d2c-4d08-9b19-157b70ba57f8.png">

## NEXT STEP
- Decide if there is only one conversation between two users and not display previous messages from previous rents, or create new conversations each rent (as it is now).
