### PR TITLE
[BACK-END REFACTOR] Moved custom resolvers definition

### DIFF
--- a/Back-end/schema/mutations.js
+++ b/Back-end/schema/mutations.js
@@ -1,3 +1,6 @@
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { UserModel } = require('./models/User');
 const {
   UserDTC,
   DriverTC,
@@ -10,6 +13,112 @@ const {
 /**
  *  Getting objects after relations are applied
  */
+
+/**
+ * Making custom resolvers for login/register
+ * mutations
+ */
+UserDTC.addResolver({
+  kind: 'mutation',
+  name: 'userRegister',
+  args: {
+    email: 'String!',
+    password: 'String!',
+    type: 'String!',
+    firstName: 'String!',
+    lastName: 'String!',
+  },
+  type: UserDTC.getResolver('updateById').getType(),
+  resolve: async ({ args /* context */ }) => {
+    let existUser = null;
+    if (isNaN(Number(args.email))) {
+      existUser = await UserModel.findOne({ email: args.email });
+    } else {
+      existUser = await UserModel.findOne({ phone: Number(args.email) });
+    }
+    if (existUser) {
+      throw new Error('User exists already.');
+    }
+    const hashedPassword = await bcrypt.hash(args.password, 12);
+    const newUser = new UserModel({
+      email: args.email,
+      password: hashedPassword,
+      type: args.type,
+      firstName: args.firstName,
+      lastName: args.lastName,
+    });
+    const result = await newUser.save();
+    return {
+      recordId: result._id,
+      record: result,
+    };
+  },
+});
+
+/**
+ * Field added in order to have a token
+ * for the login
+ */
+UserDTC.addFields({
+  token: {
+    type: 'String',
+    description: 'Token of authenticated user.',
+  },
+});
+
+UserDTC.addResolver({
+  kind: 'mutation',
+  name: 'userLogin',
+  args: {
+    email: 'String!',
+    password: 'String!',
+  },
+  type: UserDTC.getResolver('updateById').getType(),
+  resolve: async ({ args /* context */ }) => {
+    let user = null;
+    if (isNaN(Number(args.email))) {
+      user = await UserModel.findOne({ email: args.email });
+    } else {
+      user = await UserModel.findOne({ phone: Number(args.email) });
+    }
+    if (!user) {
+      throw new Error('User does not exist.');
+    }
+
+    const isEqual = await bcrypt.compare(args.password, user.password);
+    if (!isEqual) {
+      throw new Error('Password is not correct.');
+    }
+
+    const token = jwt.sign(
+      {
+        userId: user._id,
+        userEmail: user.email,
+        userPassword: user.password,
+      },
+      'secretkey',
+      {
+        expiresIn: '1h',
+      },
+    );
+
+    return {
+      recordId: user._id,
+      record: {
+        token: token,
+        _id: user._id,
+        type: user.type,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        password: user.password,
+        phone: user.phone,
+        address: user.address,
+        cards: [user.cards.map(card => card.number)],
+      },
+    };
+  },
+});
 
 const userMutations = {
   userCreate: UserDTC.getResolver('createOne'),

--- a/Back-end/schema/relations.js
+++ b/Back-end/schema/relations.js
@@ -1,6 +1,4 @@
-const bcrypt = require('bcryptjs');
-const jwt = require('jsonwebtoken');
-const { UserModel, UserDTC, OwnerTC, DriverTC } = require('./models/User');
+const { UserDTC, OwnerTC, DriverTC } = require('./models/User');
 const { ParkingTC } = require('./models/Parking');
 const { RentTC } = require('./models/Rent');
 const { ConversationTC } = require('./models/Conversation');
@@ -20,7 +18,7 @@ UserDTC.addRelation('conversations', {
     }),
   },
   /**
-   * Required fields from User object, 1=true
+   * Required fields (_id) from User object, 1=true
    */
   projection: { _id: 1 },
 });
@@ -60,107 +58,6 @@ DriverTC.addRelation('rents', {
     }),
   },
   projection: { _id: 1 },
-});
-
-/**
- * Login/Register
- */
-UserDTC.addResolver({
-  kind: 'mutation',
-  name: 'userRegister',
-  args: {
-    email: 'String!',
-    password: 'String!',
-    type: 'String!',
-    firstName: 'String!',
-    lastName: 'String!',
-  },
-  type: UserDTC.getResolver('updateById').getType(),
-  resolve: async ({ args /* context */ }) => {
-    let existUser = null;
-    if (isNaN(Number(args.email))) {
-      existUser = await UserModel.findOne({ email: args.email });
-    } else {
-      existUser = await UserModel.findOne({ phone: Number(args.email) });
-    }
-    if (existUser) {
-      throw new Error('User exists already.');
-    }
-    const hashedPassword = await bcrypt.hash(args.password, 12);
-    const newUser = new UserModel({
-      email: args.email,
-      password: hashedPassword,
-      type: args.type,
-      firstName: args.firstName,
-      lastName: args.lastName,
-    });
-    const result = await newUser.save();
-    return {
-      recordId: result._id,
-      record: result,
-    };
-  },
-});
-
-UserDTC.addFields({
-  token: {
-    type: 'String',
-    description: 'Token of authenticated user.',
-  },
-});
-
-UserDTC.addResolver({
-  kind: 'mutation',
-  name: 'userLogin',
-  args: {
-    email: 'String!',
-    password: 'String!',
-  },
-  type: UserDTC.getResolver('updateById').getType(),
-  resolve: async ({ args /* context */ }) => {
-    let user = null;
-    if (isNaN(Number(args.email))) {
-      user = await UserModel.findOne({ email: args.email });
-    } else {
-      user = await UserModel.findOne({ phone: Number(args.email) });
-    }
-    if (!user) {
-      throw new Error('User does not exist.');
-    }
-
-    const isEqual = await bcrypt.compare(args.password, user.password);
-    if (!isEqual) {
-      throw new Error('Password is not correct.');
-    }
-
-    const token = jwt.sign(
-      {
-        userId: user._id,
-        userEmail: user.email,
-        userPassword: user.password,
-      },
-      'secretkey',
-      {
-        expiresIn: '1h',
-      },
-    );
-
-    return {
-      recordId: user._id,
-      record: {
-        token: token,
-        _id: user._id,
-        type: user.type,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        email: user.email,
-        password: user.password,
-        phone: user.phone,
-        address: user.address,
-        cards: [user.cards.map(card => card.number)],
-      },
-    };
-  },
 });
 
 /**


### PR DESCRIPTION
## DESCRIPTION
- Moved login/register resolvers from relations.js to mutations.js

## MILESTONES
Not a milestone, code refactor

## TEST PLAN
Still working
Register:
<img width="1165" alt="Screen Shot 2022-08-09 at 9 44 19 AM" src="https://user-images.githubusercontent.com/37078683/183709952-4aa5f891-2c56-41a7-9db7-f1a443ea085c.png">

Login:
<img width="1163" alt="Screen Shot 2022-08-09 at 9 44 57 AM" src="https://user-images.githubusercontent.com/37078683/183709953-aaa49dfa-3e45-4943-9851-575f040b855a.png">
