### PR TITLE
[MESSENGER STYLE] fixed elements size and place

### DIFF
--- a/Front-end/parquick/src/components/Messenger/Message/Message.css
+++ b/Front-end/parquick/src/components/Messenger/Message/Message.css
@@ -1,7 +1,7 @@
 .message {
   display: flex;
   flex-direction: column;
-  margin-top: 20px;
+  margin: 5px 0px;
   align-items: flex-start;
 }
 
@@ -29,7 +29,8 @@
 
 .message-date {
   font-size: 12px;
-  margin-top: 10px;
+  font-weight: 300;
+  margin-top: -10px;
 }
 
 .message.own {

--- a/Front-end/parquick/src/components/Messenger/Messenger.css
+++ b/Front-end/parquick/src/components/Messenger/Messenger.css
@@ -55,6 +55,8 @@
 }
 textarea.chat-message-input {
   resize: none;
+  width: 100%;
+  margin-right: 15px;
 }
 
 .chat-submit-button {

--- a/Front-end/parquick/src/components/Messenger/Messenger.css
+++ b/Front-end/parquick/src/components/Messenger/Messenger.css
@@ -2,6 +2,9 @@
   display: flex;
   height: calc(100vh - 59px);
 }
+/**
+ * 59px is the navbar size
+ */
 
 .chat-menu {
   flex: 1;
@@ -18,27 +21,28 @@
 .chat-box {
   flex: 4;
   height: 100%;
-  overflow: hidden;
 }
 .chat-menu-container {
   padding: 10px;
   height: 100%;
 }
 .chat-box-container {
-  padding: 10px;
+  padding: 0 10px;
   background: rgba(161, 161, 161, 0.5);
   height: 100%;
-  overflow: scroll;
+  display: flex;
+  flex-direction: column;
 }
 
 .chat-box-messages {
   height: 100%;
-  overflow-y: scroll;
   padding-right: 10px;
+  overflow-y: scroll;
 }
 
 .chat-box-input {
   margin-top: 5px;
+  padding: 10px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -48,6 +52,9 @@
   width: 80%;
   height: 90px;
   padding: 10px;
+}
+textarea.chat-message-input {
+  resize: none;
 }
 
 .chat-submit-button {

--- a/Front-end/parquick/src/components/Messenger/Messenger.css
+++ b/Front-end/parquick/src/components/Messenger/Messenger.css
@@ -1,21 +1,34 @@
 .messenger {
   display: flex;
+  height: calc(100vh - 59px);
 }
 
 .chat-menu {
   flex: 1;
+  height: 100%;
+  overflow: scroll;
+  background: rgb(85, 85, 85);
+  background: linear-gradient(
+    0deg,
+    rgba(83, 83, 83, 0.5) 0%,
+    rgba(161, 161, 161, 0.233) 5%
+  );
 }
 
 .chat-box {
   flex: 4;
+  height: 100%;
+  overflow: hidden;
 }
 .chat-menu-container {
   padding: 10px;
-  background: rgba(161, 161, 161, 0.233);
+  height: 100%;
 }
 .chat-box-container {
   padding: 10px;
   background: rgba(161, 161, 161, 0.5);
+  height: 100%;
+  overflow: scroll;
 }
 
 .chat-box-messages {

--- a/Front-end/parquick/src/components/Messenger/Messenger.jsx
+++ b/Front-end/parquick/src/components/Messenger/Messenger.jsx
@@ -147,7 +147,7 @@ function Messenger(): React.MixedElement {
               {isLoadingMessages ? (
                 <span className="loading-messages">Loading messages ...</span>
               ) : messages?.length !== 0 ? (
-                <div className="chatbox-messages">
+                <div className="chat-box-messages">
                   {messages.map(mes => {
                     return (
                       <Message
@@ -163,7 +163,7 @@ function Messenger(): React.MixedElement {
                   {`V`} Send the first message. {`V`}
                 </span>
               )}
-              <div className="chatbox-input">
+              <div className="chat-box-input">
                 <textarea
                   className="chat-message-input"
                   placeholder="write something..."


### PR DESCRIPTION
## DESCRIPTION
- Fixed conversations column size
- Added gradient to show there are more conversations at the bottom
- Fixed personal chat size, with scroll for messages and text-area at the bottom
- Changed message-date style

## MILESTONES
CSS

## TEST PLAN
Conversations:
<img width="1091" alt="Screen Shot 2022-08-09 at 11 44 29 PM" src="https://user-images.githubusercontent.com/37078683/183834462-c43c3f3a-5d10-4d4b-8df5-1ace1813bba6.png">

Text area in the bottom:
<img width="1093" alt="Screen Shot 2022-08-09 at 11 45 09 PM" src="https://user-images.githubusercontent.com/37078683/183834570-443acf0a-b04b-417b-8e62-ccfb33ac98db.png">
